### PR TITLE
feat: use inter for ui elements

### DIFF
--- a/app/theme/custom-theme.tsx
+++ b/app/theme/custom-theme.tsx
@@ -15,9 +15,11 @@ const customTheme = extendTheme({
       },
       h1: {
         color: '#33302e',
+        fontFamily: 'var(--font-inter)',
       },
       h2: {
         color: '#33302e',
+        fontFamily: 'var(--font-inter)',
       },
     },
   },
@@ -28,6 +30,9 @@ const customTheme = extendTheme({
       },
     },
     Button: {
+      baseStyle: {
+        fontFamily: 'var(--font-inter)',
+      },
       variants: {
         solid: {
           bg: wineColor, // Wine color background
@@ -51,15 +56,27 @@ const customTheme = extendTheme({
         },
       },
     },
+    Input: {
+      baseStyle: {
+        field: {
+          fontFamily: 'var(--font-inter)',
+        },
+      },
+    },
+    FormLabel: {
+      baseStyle: {
+        fontFamily: 'var(--font-inter)',
+      },
+    },
     Card,
   },
   fonts: {
-    heading: "'Libre Baskerville', serif",
+    heading: 'var(--font-inter)',
     body: "'Libre Baskerville', serif",
   },
   Heading: {
     baseStyle: {
-      fontFamily: "'Libre Baskerville', serif",
+      fontFamily: 'var(--font-inter)',
       color: '#33302e',
     },
   },

--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,4 @@
 <link
-  href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&family=Libre+Baskerville:wght@400;700&display=swap"
+  href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&display=swap"
   rel="stylesheet"
 />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,6 +21,7 @@ export default {
       },
       fontFamily: {
         sans: ["var(--font-inter)"],
+        heading: ["var(--font-inter)"],
       },
       maxWidth: {
         "84rem": "84rem",


### PR DESCRIPTION
## Summary
- apply Inter font to Chakra components like headings, buttons, and inputs
- drop unused Merriweather font load
- expose Inter as Tailwind heading font

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: connect ENETUNREACH 151.101.163.18:443)


------
https://chatgpt.com/codex/tasks/task_e_689bce0dd3b4832bab67a90757c904f4