### PR TITLE
feat: add contact page and link

### DIFF
--- a/app/components/nav-bar.tsx
+++ b/app/components/nav-bar.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Button, Divider, Flex, Link, Text } from '@chakra-ui/react'
+import NextLink from 'next/link'
 import { usePathname } from 'next/navigation'
 import React from 'react'
 import SearchForm from './search-form'
@@ -55,6 +56,8 @@ const NavBar: React.FC = () => {
         <Flex alignItems="center" gap={{ base: 4, md: 8 }}>
           <SearchForm initialQuery={''} />
           <Button
+            as={NextLink}
+            href="/contact"
             className="bg-text-charcoal-light hover:bg-text-white hover:text-charcoal-light border border-charcoal text-white font-bold duration-200 transition-colors mb-6 lg:mb-0"
             borderRadius="0"
             backgroundColor="#33302e"

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Heading,
+  Input,
+  Link,
+  Textarea,
+} from '@chakra-ui/react'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
+
+// contactSchema validates the contact form fields
+const contactSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Invalid email'),
+  message: z.string().min(1, 'Message is required'),
+})
+
+// ContactFormData represents the data submitted by the contact form
+interface ContactFormData extends z.infer<typeof contactSchema> {}
+
+export default function ContactPage() {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<ContactFormData>({
+    resolver: zodResolver(contactSchema),
+  })
+
+  const onSubmit = (data: ContactFormData) => {
+    const mailtoLink = `mailto:d.d.hightower@gmail.com?subject=${encodeURIComponent(
+      'Website Contact'
+    )}&body=${encodeURIComponent(
+      `Name: ${data.name}\nEmail: ${data.email}\n\n${data.message}`
+    )}`
+    window.location.href = mailtoLink
+    reset()
+  }
+
+  return (
+    <Box className="container mx-auto px-5 max-w-84rem" py={10}>
+      <Heading
+        as="h1"
+        fontSize={{ base: '4xl', md: '5xl' }}
+        fontWeight="bold"
+        textShadow="1px 1px 2px rgba(0, 0, 0, 0.25)"
+        mb={8}
+      >
+        Contact
+      </Heading>
+      <Box
+        as="form"
+        onSubmit={handleSubmit(onSubmit)}
+        maxW="md"
+        display="flex"
+        flexDirection="column"
+        gap={4}
+      >
+        <FormControl isInvalid={!!errors.name}>
+          <FormLabel>Name</FormLabel>
+          <Input {...register('name')} />
+        </FormControl>
+        <FormControl isInvalid={!!errors.email}>
+          <FormLabel>Email</FormLabel>
+          <Input type="email" {...register('email')} />
+        </FormControl>
+        <FormControl isInvalid={!!errors.message}>
+          <FormLabel>Message</FormLabel>
+          <Textarea {...register('message')} />
+        </FormControl>
+        <Button
+          type="submit"
+          alignSelf="flex-start"
+          className="bg-text-charcoal-light hover:bg-text-white hover:text-charcoal-light border border-charcoal text-white font-bold duration-200 transition-colors"
+          borderRadius="0"
+          backgroundColor="#33302e"
+          _hover={{ backgroundColor: 'white', color: '#33302e' }}
+        >
+          Send
+        </Button>
+      </Box>
+      <Box mt={8}>
+        <Heading as="h2" fontSize="2xl" mb={2}>
+          Email
+        </Heading>
+        <Link href="mailto:d.d.hightower@gmail.com" color="#990f3d">
+          d.d.hightower@gmail.com
+        </Link>
+      </Box>
+    </Box>
+  )
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,13 +4,13 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "ddhightower",
       "dependencies": {
         "@chakra-ui/react": "^2.10.4",
         "@contentful/rich-text-react-renderer": "^15.17.1",
         "@contentful/rich-text-types": "^16.2.1",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
+        "@hookform/resolvers": "^3.10.0",
         "@tailwindcss/typography": "0.5.9",
         "@types/node": "^20.5.0",
         "@types/react": "^18.2.20",
@@ -28,7 +28,8 @@
         "react-slick": "^0.30.2",
         "slick-carousel": "^1.8.1",
         "tailwindcss": "^3.3.3",
-        "typescript": "^5.1.6"
+        "typescript": "^5.1.6",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/react-slick": "^0.23.13"
@@ -549,6 +550,15 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
+      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -6968,6 +6978,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@contentful/rich-text-types": "^16.2.1",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
+    "@hookform/resolvers": "^3.10.0",
     "@tailwindcss/typography": "0.5.9",
     "@types/node": "^20.5.0",
     "@types/react": "^18.2.20",
@@ -29,7 +30,8 @@
     "react-slick": "^0.30.2",
     "slick-carousel": "^1.8.1",
     "tailwindcss": "^3.3.3",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/react-slick": "^0.23.13"


### PR DESCRIPTION
## Summary
- add contact form page with email link
- link nav bar "Contact" button to the new contact route
- add form validation dependencies

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: connect ENETUNREACH 151.101.163.18:443)*

------
https://chatgpt.com/codex/tasks/task_e_689beead9bd0832b8b707ebf4324fb7c