### PR TITLE
feat: modernize contact page and add home flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ CONTENTFUL_SPACE_ID=your_contentful_space_id
 CONTENTFUL_ACCESS_TOKEN=your_contentful_access_token
 ALGOLIA_APP_ID=your_algolia_app_id
 ALGOLIA_SEARCH_API_KEY=your_algolia_search_api_key
+NEXT_PUBLIC_ENABLE_HOME=true # set to false to disable home page
 ```
 
 4. **Start the development server**:

--- a/app/components/nav-bar.tsx
+++ b/app/components/nav-bar.tsx
@@ -5,6 +5,7 @@ import NextLink from 'next/link'
 import { usePathname } from 'next/navigation'
 import React from 'react'
 import SearchForm from './search-form'
+import { HOME_PAGE_ENABLED } from '@/lib/constants'
 
 interface NavLink {
   hyperlink: string
@@ -12,14 +13,10 @@ interface NavLink {
 }
 
 const navLinks: NavLink[] = [
-  {
-    hyperlink: '/',
-    text: 'Home',
-  },
-  {
-    hyperlink: '/chapters',
-    text: 'Sample Chapters',
-  },
+  ...(HOME_PAGE_ENABLED
+    ? [{ hyperlink: '/', text: 'Home' }]
+    : []),
+  { hyperlink: '/chapters', text: 'Sample Chapters' },
 ]
 
 const NavBar: React.FC = () => {

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   FormControl,
   FormLabel,
+  FormErrorMessage,
   Heading,
   Input,
   Link,
@@ -62,26 +63,52 @@ export default function ContactPage() {
         display="flex"
         flexDirection="column"
         gap={4}
+        bg="white"
+        p={6}
+        borderRadius="md"
+        boxShadow="md"
       >
         <FormControl isInvalid={!!errors.name}>
           <FormLabel>Name</FormLabel>
-          <Input {...register('name')} />
+          <Input
+            {...register('name')}
+            bg="white"
+            borderColor="#33302e"
+            borderRadius="md"
+            focusBorderColor="#990f3d"
+          />
+          <FormErrorMessage>{errors.name?.message}</FormErrorMessage>
         </FormControl>
         <FormControl isInvalid={!!errors.email}>
           <FormLabel>Email</FormLabel>
-          <Input type="email" {...register('email')} />
+          <Input
+            type="email"
+            {...register('email')}
+            bg="white"
+            borderColor="#33302e"
+            borderRadius="md"
+            focusBorderColor="#990f3d"
+          />
+          <FormErrorMessage>{errors.email?.message}</FormErrorMessage>
         </FormControl>
         <FormControl isInvalid={!!errors.message}>
           <FormLabel>Message</FormLabel>
-          <Textarea {...register('message')} />
+          <Textarea
+            {...register('message')}
+            bg="white"
+            borderColor="#33302e"
+            borderRadius="md"
+            focusBorderColor="#990f3d"
+          />
+          <FormErrorMessage>{errors.message?.message}</FormErrorMessage>
         </FormControl>
         <Button
           type="submit"
           alignSelf="flex-start"
-          className="bg-text-charcoal-light hover:bg-text-white hover:text-charcoal-light border border-charcoal text-white font-bold duration-200 transition-colors"
-          borderRadius="0"
-          backgroundColor="#33302e"
-          _hover={{ backgroundColor: 'white', color: '#33302e' }}
+          borderRadius="md"
+          bg="#33302e"
+          color="white"
+          _hover={{ bg: 'white', color: '#33302e' }}
         >
           Send
         </Button>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,15 @@
 import { getAllBlogPosts } from '@/lib/api'
+import { HOME_PAGE_ENABLED } from '@/lib/constants'
 import { Box, Heading } from '@chakra-ui/react'
+import { redirect } from 'next/navigation'
 import Carousel from './components/carousel'
 import Intro from './components/intro'
 
 export default async function Page() {
+  if (!HOME_PAGE_ENABLED) {
+    redirect('/chapters')
+  }
+
   // Retrieve blog posts
   const allBlogPosts = await getAllBlogPosts(false)
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,3 +1,11 @@
 export const EXAMPLE_PATH = "cms-contentful";
 export const CMS_NAME = "Contentful";
 export const CMS_URL = "https://www.contentful.com";
+
+/**
+ * HOME_PAGE_ENABLED toggles visibility of the home page. Set
+ * NEXT_PUBLIC_ENABLE_HOME to 'false' to disable the home page and
+ * redirect users to sample chapters instead.
+ */
+export const HOME_PAGE_ENABLED =
+  process.env.NEXT_PUBLIC_ENABLE_HOME !== 'false';


### PR DESCRIPTION
## Summary
- restyle contact form with modern card layout and distinct input styling
- introduce feature flag to disable the home page and redirect to sample chapters
- document new `NEXT_PUBLIC_ENABLE_HOME` environment variable

## Testing
- `npm test` *(fails: Missing script "test")*
- `NEXT_PUBLIC_ENABLE_HOME=false CONTENTFUL_SPACE_ID=foo CONTENTFUL_ACCESS_TOKEN=bar ALGOLIA_APP_ID=foo ALGOLIA_SEARCH_API_KEY=foo npm run build` *(fails: Fetch to external Contentful API: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_689c13cd1430832baef2d41973d029a3