### PR TITLE
feat: add social links to footer

### DIFF
--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -1,4 +1,5 @@
-import { Divider, Flex, Text } from '@chakra-ui/react'
+import { Divider, Flex, Link, Text } from '@chakra-ui/react'
+import { socialLinks } from './header-bar'
 
 const Footer = () => {
   return (
@@ -9,7 +10,21 @@ const Footer = () => {
       justifyContent={'center'}
     >
       <Divider borderColor={'#33302e'} opacity={0.25} />
-      <Text fontSize="sm" py={8}>
+      <Flex gap={4} py={4}>
+        {socialLinks.map((link, index) => (
+          <Link
+            _hover={{ color: '#FFF1E0' }}
+            flexShrink={0}
+            href={link.hyperlink}
+            key={index}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            {link.icon}
+          </Link>
+        ))}
+      </Flex>
+      <Text fontSize="sm" pb={8}>
         © 2025 D. D. Hightower. All Rights Reserved
       </Text>
     </Flex>

--- a/app/components/header-bar.tsx
+++ b/app/components/header-bar.tsx
@@ -8,12 +8,14 @@ import {
   FaYoutube,
 } from "react-icons/fa6";
 
-interface SocialLink {
+// SocialLink represents a single social media link with its icon and URL
+export interface SocialLink {
   icon: JSX.Element;
   hyperlink: string;
 }
 
-const socialLinks: SocialLink[] = [
+// socialLinks contains all of the author's public social profiles
+export const socialLinks: SocialLink[] = [
   // {
   //   icon: <FaDiscord size={"24"} />,
   //   hyperlink: "https://x.com/",


### PR DESCRIPTION
## Summary
- export reusable social link data
- display social links in footer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: connect ENETUNREACH 146.75.107.18:443)*

------
https://chatgpt.com/codex/tasks/task_e_689cabe4fa3c832b9ac62931d3323d1d