### PR TITLE
Use stock imagery for chapter listings

### DIFF
--- a/app/chapters/page.tsx
+++ b/app/chapters/page.tsx
@@ -10,13 +10,17 @@ const HERO_SLUG = 'prologue'
 
 function HeroPost({
   title,
-  coverImage,
+  /**
+   * URL for the hero post's cover image.
+   * Uses a static stock image rather than a CMS-provided asset.
+   */
+  coverImageUrl,
   date,
   excerpt,
   slug,
 }: {
   title: string
-  coverImage: any
+  coverImageUrl: string
   date: string
   excerpt: string
   slug: string
@@ -32,7 +36,7 @@ function HeroPost({
       <CoverImage
         title={title}
         slug={slug}
-        url={coverImage.url}
+        url={coverImageUrl}
         zoomOnHover={true}
       />
       <Text fontSize="md" color="gray.500" mb={2}>
@@ -53,7 +57,7 @@ export default async function Page() {
       {heroPost && (
         <HeroPost
           title={heroPost.title}
-          coverImage={heroPost.coverImage}
+          coverImageUrl="/hero-chapter.jpg"
           date={heroPost.date}
           slug={heroPost.slug}
           excerpt={heroPost.excerpt}

--- a/app/components/carousel.tsx
+++ b/app/components/carousel.tsx
@@ -116,7 +116,7 @@ const Carousel: React.FC<CarouselItem> = ({
             <ItemPreview
               route="blog"
               title={post.title ?? ''}
-              imageSrc={post.coverImage?.url ?? ''}
+              imageSrc={post.coverImage?.url ?? undefined}
               date={post.date ?? ''}
               slug={post.slug ?? ''}
               excerpt={post.excerpt ?? ''}

--- a/app/components/item-preview.tsx
+++ b/app/components/item-preview.tsx
@@ -1,11 +1,15 @@
 import ContentfulImage from '@/lib/contentful-image'
-import { Flex, Heading, Link, Text } from '@chakra-ui/react'
+import { Flex, Heading, Icon, Link, Text } from '@chakra-ui/react'
 import React from 'react'
+import { FaBook } from 'react-icons/fa'
 import { formattedDate } from '../util/formatted-date'
 
 type ContentProps = Readonly<{
   route: string
-  imageSrc: string
+  /**
+   * Optional image source. When omitted, a book icon is rendered.
+   */
+  imageSrc?: string
   date: string
   title: string
   excerpt: string
@@ -20,8 +24,10 @@ const ItemPreview: React.FC<ContentProps> = ({
   excerpt,
   slug,
 }) => {
-  const image = (
+  const image = imageSrc ? (
     <ContentfulImage alt="Contentful Image" src={imageSrc} mb={4} width={512} />
+  ) : (
+    <Icon as={FaBook} boxSize={32} mb={4} />
   )
 
   return (

--- a/app/components/more-stories.tsx
+++ b/app/components/more-stories.tsx
@@ -30,7 +30,7 @@ const MoreStories: React.FC<MoreItemsProps> = ({ route, morePosts }) => {
               key={post.slug}
               route={route}
               title={post.title}
-              imageSrc={post.coverImage?.url}
+              imageSrc={route === 'chapters' ? undefined : post.coverImage?.url} // Use stock icon for chapter cards
               date={post.date}
               slug={post.slug}
               excerpt={post.excerpt}


### PR DESCRIPTION
## Summary
- Replace Contentful thumbnails for chapter cards with a book icon
- Swap chapter hero image for a static stock photo
- Ensure blog carousel continues to show post images
- Remove temporary hero image asset from repo

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Object literal may only specify known properties, and 'next' does not exist in type 'RequestInit')*
- `npm run build` *(fails: connect ENETUNREACH 146.75.107.18:443)*

------
https://chatgpt.com/codex/tasks/task_e_689cac30e518832b9f003a1fe257c4d8