### PR TITLE
Add loading skeleton for hero cover image

### DIFF
--- a/app/chapters/page.tsx
+++ b/app/chapters/page.tsx
@@ -47,6 +47,7 @@ function HeroPost({
         slug={slug}
         url={coverImageUrl}
         zoomOnHover={true}
+        showSkeleton
       />
       <Text fontSize="md" color="gray.500" mb={2}>
         {formattedDate(date)}

--- a/app/cover-image.tsx
+++ b/app/cover-image.tsx
@@ -1,11 +1,16 @@
-import { Box, Image } from '@chakra-ui/react'
+"use client"
+
+import { Box, Image, Skeleton } from '@chakra-ui/react'
 import Link from 'next/link'
+import { useState } from 'react'
 
 type CoverImageProps = Readonly<{
   title: string
   url: string
   slug?: string
   zoomOnHover?: boolean
+  /** Display a loading skeleton while the image loads. */
+  showSkeleton?: boolean
 }>
 
 export default function CoverImage({
@@ -13,7 +18,10 @@ export default function CoverImage({
   url,
   slug,
   zoomOnHover = false,
+  showSkeleton = false,
 }: Readonly<CoverImageProps>) {
+  const [isLoaded, setIsLoaded] = useState(false)
+
   const optimizedUrl = `${'https://spellshore-web-pull.b-cdn.net/runic_map.png'}?q=${90}&fm=webp&fit=fill`
 
   const image = (
@@ -31,17 +39,31 @@ export default function CoverImage({
       objectFit="cover"
       cursor={slug ? 'pointer' : 'default'}
       fetchPriority="high"
+      onLoad={() => setIsLoaded(true)}
     />
+  )
+
+  const display = showSkeleton ? (
+    <Skeleton
+      isLoaded={isLoaded}
+      height="384px"
+      width="100%"
+      borderRadius="lg"
+    >
+      {image}
+    </Skeleton>
+  ) : (
+    image
   )
 
   return (
     <Box className="sm:mx-0">
       {slug ? (
         <Link href={`/chapters/${slug}`} aria-label={title}>
-          {image}
+          {display}
         </Link>
       ) : (
-        image
+        display
       )}
     </Box>
   )


### PR DESCRIPTION
## Summary
- show Chakra UI skeleton while a cover image loads
- enable skeleton on the chapter hero post

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (hangs at "Creating an optimized production build ...")


------
https://chatgpt.com/codex/tasks/task_e_689cd0374264832bb699907156857c32