### PR TITLE
feat: add shadow to cover image

### DIFF
--- a/app/cover-image.tsx
+++ b/app/cover-image.tsx
@@ -32,6 +32,8 @@ export default function CoverImage({
   }, [])
 
   const optimizedUrl = `${'https://spellshore-web-pull.b-cdn.net/runic_map.png'}?q=${90}&fm=webp&fit=fill`
+  // Shared shadow styling for both the skeleton and the image
+  const imageShadow = '0 8px 16px rgba(0, 0, 0, 0.2), 0 -4px 8px rgba(0, 0, 0, 0.1)'
 
   const image = (
     <Image
@@ -42,7 +44,7 @@ export default function CoverImage({
       height="auto"
       maxH={'384px'}
       borderRadius={'lg'}
-      boxShadow="0 8px 16px rgba(0, 0, 0, 0.2), 0 -4px 8px rgba(0, 0, 0, 0.1)"
+      boxShadow={imageShadow}
       transition="transform 0.2s ease-in-out"
       _hover={zoomOnHover ? { transform: 'scale(1.024)' } : undefined}
       objectFit="cover"
@@ -59,6 +61,7 @@ export default function CoverImage({
       height="384px"
       width="100%"
       borderRadius="lg"
+      boxShadow={imageShadow}
     >
       {image}
     </Skeleton>


### PR DESCRIPTION
## Summary
- add shared shadow to CoverImage image and skeleton

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: fetch failed to collect page data for /blog/[slug])

------
https://chatgpt.com/codex/tasks/task_e_68a3fda9ad08832ba17132dc3d735d3f