### PR TITLE
feat: add shading overlay to cover image

### DIFF
--- a/app/cover-image.tsx
+++ b/app/cover-image.tsx
@@ -1,4 +1,4 @@
-"use client"
+'use client'
 
 import { Box, Image, Skeleton } from '@chakra-ui/react'
 import Link from 'next/link'
@@ -56,15 +56,22 @@ export default function CoverImage({
   const content = (
     <Box position="relative">
       {showSkeleton ? (
-        <Skeleton isLoaded={isLoaded} height="384px" width="100%" borderRadius="lg">
+        <Skeleton
+          startColor="#FFF1E0"
+          endColor="whiteAlpha.200"
+          isLoaded={isLoaded}
+          height="384px"
+          width="100%"
+          borderRadius="lg"
+        >
           {image}
         </Skeleton>
       ) : (
         image
       )}
       <Box
-        bg="blackAlpha.600"
-        backdropFilter="saturate(120%) blur(2px)"
+        bg="whiteAlpha.200"
+        backdropFilter="saturate(120%) "
         inset="0"
         position="absolute"
         zIndex="1"

--- a/app/cover-image.tsx
+++ b/app/cover-image.tsx
@@ -4,6 +4,7 @@ import { Box, Image, Skeleton } from '@chakra-ui/react'
 import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
 
+/** Props for the CoverImage component. */
 type CoverImageProps = Readonly<{
   title: string
   url: string
@@ -42,7 +43,6 @@ export default function CoverImage({
       height="auto"
       maxH={'384px'}
       borderRadius={'lg'}
-      boxShadow="0 8px 16px rgba(0, 0, 0, 0.2), 0 -4px 8px rgba(0, 0, 0, 0.1)"
       transition="transform 0.2s ease-in-out"
       _hover={zoomOnHover ? { transform: 'scale(1.024)' } : undefined}
       objectFit="cover"
@@ -53,27 +53,35 @@ export default function CoverImage({
     />
   )
 
-  const display = showSkeleton ? (
-    <Skeleton
-      isLoaded={isLoaded}
-      height="384px"
-      width="100%"
-      borderRadius="lg"
-    >
-      {image}
-    </Skeleton>
-  ) : (
-    image
+  const content = (
+    <Box position="relative">
+      {showSkeleton ? (
+        <Skeleton isLoaded={isLoaded} height="384px" width="100%" borderRadius="lg">
+          {image}
+        </Skeleton>
+      ) : (
+        image
+      )}
+      <Box
+        bg="blackAlpha.600"
+        backdropFilter="saturate(120%) blur(2px)"
+        inset="0"
+        position="absolute"
+        zIndex="1"
+        pointerEvents="none"
+        borderRadius="lg"
+      />
+    </Box>
   )
 
   return (
     <Box className="sm:mx-0">
       {slug ? (
         <Link href={`/chapters/${slug}`} aria-label={title}>
-          {display}
+          {content}
         </Link>
       ) : (
-        display
+        content
       )}
     </Box>
   )

--- a/app/cover-image.tsx
+++ b/app/cover-image.tsx
@@ -41,8 +41,9 @@ export default function CoverImage({
       src={optimizedUrl}
       width="100%"
       height="auto"
-      maxH={'384px'}
-      borderRadius={'lg'}
+      maxH="384px"
+      borderRadius="lg"
+      boxShadow="0 8px 16px rgba(0, 0, 0, 0.2), 0 -4px 8px rgba(0, 0, 0, 0.1)"
       transition="transform 0.2s ease-in-out"
       _hover={zoomOnHover ? { transform: 'scale(1.024)' } : undefined}
       objectFit="cover"
@@ -80,6 +81,8 @@ export default function CoverImage({
       />
     </Box>
   )
+
+  // TODO: blur the sides, increase the whiteAlpha when it is loaded as a chapter page
 
   return (
     <Box className="sm:mx-0">


### PR DESCRIPTION
## Summary
- wrap cover image (and skeleton) in a relative `<Box>` container
- overlay with absolute positioned `<Box>` to provide darkened shading
- drop old box shadow styling from image

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Failed to collect page data for /blog/[slug])*

------
https://chatgpt.com/codex/tasks/task_e_68a4017aed04832b9e8b048faf3f0b38