### PR TITLE
Use IM Fell English font for headings

### DIFF
--- a/app/cover-image.tsx
+++ b/app/cover-image.tsx
@@ -30,7 +30,7 @@ export default function CoverImage({
     if (imageRef.current?.complete) {
       setIsLoaded(true)
     }
-  }, [])
+  }, [imageRef])
 
   const optimizedUrl = `${'https://spellshore-web-pull.b-cdn.net/runic_map.png'}?q=${90}&fm=webp&fit=fill`
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import { ChakraProvider, Flex } from '@chakra-ui/react'
-import { Inter } from 'next/font/google'
+import { Inter, IM_Fell_English } from 'next/font/google'
 import Footer from './components/footer'
 import HeaderBar from './components/header-bar'
 import NavBar from './components/nav-bar'
@@ -14,16 +14,27 @@ const inter = Inter({
   display: 'swap',
 })
 
+const imFell = IM_Fell_English({
+  variable: '--font-im-fell',
+  subsets: ['latin'],
+  display: 'swap',
+  weight: '400',
+})
+
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
   return (
-    <html lang="en" className={inter.variable}>
+    <html lang="en" className={`${inter.variable} ${imFell.variable}`}>
       <head>
         <title>{metadata.title}</title>
         <meta name="description" content={metadata.description} />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&family=Libre+Baskerville:wght@400;700&display=swap"
+          rel="stylesheet"
+        />
       </head>
       <body>
         <ChakraProvider cssVarsRoot="body" theme={customTheme}>

--- a/app/theme/custom-theme.tsx
+++ b/app/theme/custom-theme.tsx
@@ -54,12 +54,12 @@ const customTheme = extendTheme({
     Card,
   },
   fonts: {
-    heading: "'Libre Baskerville', serif",
+    heading: "var(--font-im-fell), serif",
     body: "'Libre Baskerville', serif",
   },
   Heading: {
     baseStyle: {
-      fontFamily: "'Libre Baskerville', serif",
+      fontFamily: "var(--font-im-fell), serif",
       color: '#33302e',
     },
   },

--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,0 @@
-<link
-  href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&family=Libre+Baskerville:wght@400;700&display=swap"
-  rel="stylesheet"
-/>


### PR DESCRIPTION
## Summary
- load IM Fell English via `next/font` and expose variable on root html
- apply IM Fell English to Chakra heading styles
- remove `public/index.html` and move Google Fonts link into app layout

## Testing
- `npm run build` *(fails: Failed to collect page data for /chapters/[slug])*

------
https://chatgpt.com/codex/tasks/task_e_68a4e47364b4832b8a15d8c3e792d2f9